### PR TITLE
Car shadow alpha override

### DIFF
--- a/mc2hook/mc2hook/handlers/CarShadowHandler.cpp
+++ b/mc2hook/mc2hook/handlers/CarShadowHandler.cpp
@@ -1,0 +1,19 @@
+#include "CarShadowHandler.h"
+
+void CarShadowHandler::SetColor_Hook(float a1)
+{
+    hook::StaticThunk<0x5EE630>::Call<void>(0.0f); // Call original with a custom paramater
+}
+
+void CarShadowHandler::Install()
+{
+    bool applyCarShadowOpacity = HookConfig::GetBool("Graphics", "ApplyCarShadowOpacity", true);
+
+    if (!applyCarShadowOpacity)
+    {
+        InstallCallback("Car Shadow Handler", "Car shadow opacity control",
+            &SetColor_Hook, {
+                cb::call(0x4CAF23)
+            });
+    }
+}

--- a/mc2hook/mc2hook/handlers/CarShadowHandler.h
+++ b/mc2hook/mc2hook/handlers/CarShadowHandler.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <mc2hook\mc2hook.h>
+
+class CarShadowHandler
+{
+public:
+    static void SetColor_Hook(float a1);
+    static void Install();
+};

--- a/mc2hook/mc2hook/handlers/handlers.h
+++ b/mc2hook/mc2hook/handlers/handlers.h
@@ -17,6 +17,7 @@
 #include <handlers\InputHandler.h>
 #include <handlers\BorderlessHandler.h>
 #include <handlers\ReflectionFidelityHandler.h>
+#include <handlers/CarShadowHandler.h>
 
 #include <handlers\StateResearchHook.h>
 
@@ -50,6 +51,7 @@ static void InstallMainHandlers()
     InstallHandler<ChatHandler>("Chat Handler");
     InstallHandler<InitHandler>("Game Init Handler");
     InstallHandler<ReflectionFidelityHandler>("Reflection Fidelity Handller");
+    InstallHandler<CarShadowHandler>("Car Shadow Handler");
 
     InstallHandler<StateResearchHook>("SRH");
 }

--- a/mc2hook/mc2hook/mc2hook.vcxproj
+++ b/mc2hook/mc2hook/mc2hook.vcxproj
@@ -188,6 +188,7 @@
     <ClInclude Include="framework\hook_framework.h" />
     <ClInclude Include="framework\hook_output.h" />
     <ClInclude Include="handlers\BorderlessHandler.h" />
+    <ClInclude Include="handlers\CarShadowHandler.h" />
     <ClInclude Include="handlers\ChatHandler.h" />
     <ClInclude Include="handlers\CustomExceptionHandler.h" />
     <ClInclude Include="handlers\CustomVehicleHandler.h" />
@@ -241,6 +242,7 @@
     <ClCompile Include="framework\HookConfig.cpp" />
     <ClCompile Include="framework\hook_output.cpp" />
     <ClCompile Include="handlers\BorderlessHandler.cpp" />
+    <ClCompile Include="handlers\CarShadowHandler.cpp" />
     <ClCompile Include="handlers\ChatHandler.cpp" />
     <ClCompile Include="handlers\CustomExceptionHandler.cpp" />
     <ClCompile Include="handlers\CustomVehicleHandler.cpp" />


### PR DESCRIPTION
This disables the additional transparency added on the car shadow in the code, which allows you to control the transparency solely through the alpha of the shadow texture, allowing for darker more realistic car shadow as seen here. 
<img width="1895" height="991" alt="image" src="https://github.com/user-attachments/assets/cbaee8e8-5e20-4e29-845b-843ff25c72c4" />
