### PR TITLE
Burnout FPS dependency fix

### DIFF
--- a/mc2hook/mc2hook/handlers/BurnoutHandler.cpp
+++ b/mc2hook/mc2hook/handlers/BurnoutHandler.cpp
@@ -1,0 +1,48 @@
+#include "BurnoutHandler.h"
+#include <age/data/timemgr.h>
+
+static float burnoutIncreaseSpeed = 0.0f;
+static float burnoutDecreaseSpeed = 0.0f;
+static float burnoutDamageAmount = 0.0f;
+
+static float burnoutIncreaseSpeedCached = 0.0f;
+static float burnoutDecreaseSpeedCached = 0.0f;
+static float burnoutDamageAmountCached = 0.0f;
+
+static float physicsFixesBaselineFPS = 0.0f;
+
+static bool vehCarSimValuesCached = false;
+
+void BurnoutHandler::vehCarSimUpdate()
+{
+    hook::Thunk<0x4D3290>::Call<void>(this); // call original
+
+    if (vehCarSimValuesCached == false)
+    {
+        burnoutIncreaseSpeedCached = *getPtr<float>(this, 0x190);
+        burnoutDecreaseSpeedCached = *getPtr<float>(this, 0x194);
+        burnoutDamageAmountCached = *getPtr<float>(this, 0x198);
+        vehCarSimValuesCached = true;
+    }
+
+    burnoutIncreaseSpeed = burnoutIncreaseSpeedCached * datTimeManager::GetSeconds() * physicsFixesBaselineFPS;
+    burnoutDecreaseSpeed = burnoutDecreaseSpeedCached * datTimeManager::GetSeconds() * physicsFixesBaselineFPS;
+    burnoutDamageAmount = burnoutDamageAmountCached * datTimeManager::GetSeconds() * physicsFixesBaselineFPS;
+
+    *getPtr<float>(this, 0x190) = burnoutIncreaseSpeed;
+    *getPtr<float>(this, 0x194) = burnoutDecreaseSpeed;
+    *getPtr<float>(this, 0x198) = burnoutDamageAmount;
+}
+
+void BurnoutHandler::Install()
+{
+    physicsFixesBaselineFPS = HookConfig::GetFloat("Physics", "PhysicsFixesBaselineFPS", 30.0f);
+
+    // Cap physics at 30fps as a lowest possible value
+    if (physicsFixesBaselineFPS < 30.0f)
+    {
+        physicsFixesBaselineFPS = 30.0f;
+    }
+
+    InstallVTableHook("vehCarSim Some Update", &vehCarSimUpdate, { 0x644A6C });
+}

--- a/mc2hook/mc2hook/handlers/BurnoutHandler.h
+++ b/mc2hook/mc2hook/handlers/BurnoutHandler.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <mc2hook\mc2hook.h>
+
+class BurnoutHandler
+{
+public:
+    void vehCarSimUpdate();
+    static void Install();
+};

--- a/mc2hook/mc2hook/handlers/handlers.h
+++ b/mc2hook/mc2hook/handlers/handlers.h
@@ -17,6 +17,7 @@
 #include <handlers\InputHandler.h>
 #include <handlers\BorderlessHandler.h>
 #include <handlers\ReflectionFidelityHandler.h>
+#include <handlers/BurnoutHandler.h>
 
 #include <handlers\StateResearchHook.h>
 
@@ -35,6 +36,7 @@ static void InstallHandlersPostEngineInit()
     InstallHandler<PathHandler>("Path Handler");
     InstallHandler<TestPanelHandler>("Panel Handler (Keyboard input test really)");
     InstallHandler<vehTransmissionHandler>("Transmission Handler");
+    InstallHandler<BurnoutHandler>("Burnout Handler");
 }
 
 // Installed at game launch

--- a/mc2hook/mc2hook/mc2hook.vcxproj
+++ b/mc2hook/mc2hook/mc2hook.vcxproj
@@ -188,6 +188,7 @@
     <ClInclude Include="framework\hook_framework.h" />
     <ClInclude Include="framework\hook_output.h" />
     <ClInclude Include="handlers\BorderlessHandler.h" />
+    <ClInclude Include="handlers\BurnoutHandler.h" />
     <ClInclude Include="handlers\ChatHandler.h" />
     <ClInclude Include="handlers\CustomExceptionHandler.h" />
     <ClInclude Include="handlers\CustomVehicleHandler.h" />
@@ -241,6 +242,7 @@
     <ClCompile Include="framework\HookConfig.cpp" />
     <ClCompile Include="framework\hook_output.cpp" />
     <ClCompile Include="handlers\BorderlessHandler.cpp" />
+    <ClCompile Include="handlers\BurnoutHandler.cpp" />
     <ClCompile Include="handlers\ChatHandler.cpp" />
     <ClCompile Include="handlers\CustomExceptionHandler.cpp" />
     <ClCompile Include="handlers\CustomVehicleHandler.cpp" />

--- a/mc2hook/mc2hook/mc2hook.vcxproj.filters
+++ b/mc2hook/mc2hook/mc2hook.vcxproj.filters
@@ -219,6 +219,9 @@
     <ClInclude Include="handlers\ReflectionFidelityHandler.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="handlers\BurnoutHandler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -339,6 +342,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="handlers\ReflectionFidelityHandler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="handlers\BurnoutHandler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
This makes burnout fps-independent. Also exposes a base fps value for such effects. By default it is 30 FPS as it was originally on the consoles.