### PR TITLE
OpenSpy made optional, default is enabled

### DIFF
--- a/mc2hook/mc2hook/handlers/OpenSpyHandler.cpp
+++ b/mc2hook/mc2hook/handlers/OpenSpyHandler.cpp
@@ -2,9 +2,13 @@
 
 void OpenSpyHandler::Install()
 {
-    // replace 'gamespy.com' portion of the following URLs with 'openspy.net'
-    mem::write_string(0x64F3D4, "openspy.net"); // %s.ms%d.gamespy.com
-    mem::write_string(0x64F45C, "openspy.net"); // natneg2.gamespy.com
-    mem::write_string(0x64F470, "openspy.net"); // natneg1.gamespy.com
-    mem::write_string(0x64F4AA, "openspy.net"); // %s.master.gamespy.com
-}   
+    bool enableOpenSpy = HookConfig::GetBool("Experimental", "EnableOpenSpy", true);
+    if (enableOpenSpy)
+    {
+        // replace 'gamespy.com' portion of the following URLs with 'openspy.net'
+        mem::write_string(0x64F3D4, "openspy.net"); // %s.ms%d.gamespy.com
+        mem::write_string(0x64F45C, "openspy.net"); // natneg2.gamespy.com
+        mem::write_string(0x64F470, "openspy.net"); // natneg1.gamespy.com
+        mem::write_string(0x64F4AA, "openspy.net"); // %s.master.gamespy.com
+    }
+}


### PR DESCRIPTION
Made the OpenSpy handler optional as per request. In some cases it was blocking/interfering with certain game setups. Default is enabled.